### PR TITLE
Update McCalibre.css

### DIFF
--- a/McCalibre.css
+++ b/McCalibre.css
@@ -9,6 +9,7 @@ body {
 	height: 100%;
 	margin: 0;
 	padding: 0;
+	max-width: none !important;
 
 	/* column-width seems to be treated as a suggestion; actual width
 	is varied to fit an even number of columns within screen width. */


### PR DESCRIPTION
Fix: In fullscreen flow mode there's a "body { max-width: 800px; margin-left: auto; margin-right: auto; }" to produce a center column for improved readability.
